### PR TITLE
Garantindo que o dicionário seja inicializado apenas uma vez.

### DIFF
--- a/Source/RepositorioGenerico/Dictionary/Dicionario.cs
+++ b/Source/RepositorioGenerico/Dictionary/Dicionario.cs
@@ -37,7 +37,7 @@ namespace RepositorioGenerico.Dictionary
 		private readonly bool _possuiReferencial;
 		private bool _possuiCamposFilhos;
 		private readonly IMapa _mapa;
-		private bool _carregando = true;
+		private readonly Lazy<bool> _carregando;
 
 		public string Alias { get; private set; }
 
@@ -142,6 +142,20 @@ namespace RepositorioGenerico.Dictionary
 			if (string.Equals(Nome, Alias) || string.IsNullOrEmpty(Alias))
 				Alias = null;
 			_possuiCamposFilhos = false;
+			_carregando = new Lazy<bool>(InicializarMapeamento, LazyThreadSafetyMode.ExecutionAndPublication);
+		}
+
+		public bool InicializarMapeamento()
+		{
+			_itens = new Dictionary<string, ItemDicionario>();
+			_listaItens = new List<ItemDicionario>();
+			_itensNaoMapeados = new Dictionary<string, ItemDicionario>();
+			_propriedades = new Dictionary<string, ItemDicionario>();
+			_propriedadesNaoMapeadas = new Dictionary<string, ItemDicionario>();
+			_chaves = new Dictionary<string, ItemDicionario>();
+			CarregarCamposDaTabela();
+			CarregarValidadoresDoModel();
+			return true;
 		}
 
 		private bool ObjetoPossuiOutroObjetoReferenciado(Type tipo)
@@ -153,28 +167,7 @@ namespace RepositorioGenerico.Dictionary
 
 		private void CarregarDefinicoesDoModel()
 		{
-			if (_itens != null)
-			{
-				while (_carregando)
-					Thread.Sleep(10);
-				return;
-			}
-
-			try
-			{
-				_itens = new Dictionary<string, ItemDicionario>();
-				_listaItens = new List<ItemDicionario>();
-				_itensNaoMapeados = new Dictionary<string, ItemDicionario>();
-				_propriedades = new Dictionary<string, ItemDicionario>();
-				_propriedadesNaoMapeadas = new Dictionary<string, ItemDicionario>();
-				_chaves = new Dictionary<string, ItemDicionario>();
-				CarregarCamposDaTabela();
-				CarregarValidadoresDoModel();
-			}
-			finally
-			{
-				_carregando = false;
-			}
+			var _ = _carregando.Value;
 		}
 
 		private void CarregarCamposDaTabela()
@@ -233,7 +226,7 @@ namespace RepositorioGenerico.Dictionary
 					throw new DicionarioNaoSuportaMultiplosCamposAutoIncrementoException();
 				_autoIncremento = OpcoesAutoIncremento.Calculado;
 			}
-			
+
 			if ((camposIdentity > 0) && (camposAgrupados > 0))
 				throw new DicionarioNaoSuportaMultiplosCamposAutoIncrementoException();
 		}

--- a/Source/Tests/RepositorioGenerico.Test/Dictionary/DicionarioCacheUnitTest.cs
+++ b/Source/Tests/RepositorioGenerico.Test/Dictionary/DicionarioCacheUnitTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RepositorioGenerico.Dictionary;
@@ -37,6 +39,28 @@ namespace RepositorioGenerico.Test.Dictionary
 						vezes++;
 				});
 			vezes.Should().Be(100000);
+		}
+
+		[TestMethod]
+		public void SeConsultarDicionarioEmParaleloNaoDeveExporEstadoParcial()
+		{
+			var erros = new ConcurrentBag<Exception>();
+
+			Parallel.For(0, 100000, _ =>
+			{
+				try
+				{
+					var dicionario = DicionarioCache.Consultar(typeof(ObjetoDeTestes));
+					dicionario.QuantidadeCamposNaChave.Should().BeGreaterThan(0);
+					dicionario.Itens.Should().NotBeEmpty();
+				}
+				catch (Exception ex)
+				{
+					erros.Add(ex);
+				}
+			});
+
+			erros.Should().BeEmpty();
 		}
 
 	}


### PR DESCRIPTION
Ao usar Lazy<bool>, o objeto é criado no construtor, mas o método InicializarMapeamento() só é executado quando alguém acessa o .Value pela primeira vez. Então, o sistema garante que apenas uma execução aconteça, mesmo que várias partes do programa tentem acessar ao mesmo tempo. Depois que termina, o resultado fica guardado e qualquer novo acesso apenas reutiliza esse valor já cacheado.